### PR TITLE
Allow jupyterlab to start automatically

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
                 8000,
                 8888
             ],
-            "postAttachCommand": ["./requirements/server-launch.sh"],
             // Visual Studio Code environment configuration
             "settings": {
                 // Set the default terminal application to bash
@@ -50,5 +49,9 @@
                 "python.formatting.provider": "autopep8"
             }
         }
-    }
+    },
+    // Entrypoint gets overridden by default by vscode, so run the script to start JupyterLab
+    "postStartCommand": [
+        "./requirements/server-launch.sh"
+    ]
 }


### PR DESCRIPTION
The jupyterlab and mkdocs script didn't appear to be executing upon container startup. This was likely due to ENTRYPOINT getting overridden by default by vscode, and the postAttachCommand didn't appear to be working.  I was able to get it to start with the container by adding the script to the `postStartCommand` setting in the container config.  

This is an awesome resource by the way,  thank you!